### PR TITLE
Update get-involved

### DIFF
--- a/get-involved/index.html
+++ b/get-involved/index.html
@@ -5,7 +5,7 @@ title: Get Involved
 
 <h1>Get Involved</h1>
 
-<p>There are opportunities to get involved in all phases of the organization’s activities as a member of LUrC. There is no fee to join. In exchange for work, members share the products of the harvest. If you are interested in joining us for any of these activities, please sign up to be a member using the following <a href="http://leagueofurbancanners.herokuapp.com/users/sign_up">form</a>. If you would just like to keep abreast of our activities, you can sign up for the listserv <a href="https://groups.google.com/group/leagueofurbancanners/subscribe">here</a>.</p>
+<p>There are opportunities to get involved in all phases of the organization’s activities as a member of LUrC. There is no fee to join. In exchange for work, members share the products of the harvest. If you are interested in joining us for any of these activities, please sign up for the listserv <a href="https://groups.google.com/group/leagueofurbancanners/subscribe">here</a>.</p>
 
 <h2>Pruning</h2>
 


### PR DESCRIPTION
removed link to defunct sign-up form; signing up for listserv is the primary means of contact.
